### PR TITLE
Switch to self hosted runner

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,7 @@ name: Check
 jobs:
   check:
     name: Run Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, non-gpu]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,8 @@ name: Check
 jobs:
   check:
     name: Run Unit Tests
-    runs-on: [self-hosted, linux, non-gpu]
+    # For public repo's GH recommends not using self hosted
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,7 +8,7 @@ name: Package
 jobs:
   check:
     name: Package distribution file
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, non-gpu]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,7 +8,8 @@ name: Package
 jobs:
   check:
     name: Package distribution file
-    runs-on: [self-hosted, linux, non-gpu]
+    # For public repo's GH recommends not using self hosted
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
Summary:
The github runner was failing without any errors. While investigating we
realized we are not using the self hosted runners.