### PR TITLE
chore: bump node version to 16 bc gh is deprecating node 12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,5 +32,5 @@ outputs:
   task-arn-list:
     description: 'List of ARNs of the ECS task(s) run'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Seeing the following warning about updating from node 12 to node 16 when using this action:


> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, aws-actions/configure-aws-credentials@v1, researchsquare/run-ecs-task-action@v1
